### PR TITLE
pkg(ghc-cross): Enable `iserv` build

### DIFF
--- a/free-space.sh
+++ b/free-space.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
-df -h
+# df -h
 
 sudo apt purge -yq $(dpkg -l | grep '^ii' | awk '{ print $2 }' | grep -P '(aspnetcore|cabal-|dotnet-|ghc-|libmono|mongodb-|mysql-|llvm-|liblldb-|php)') \
   firefox google-chrome-stable microsoft-edge-stable mono-devel mono-runtime-common monodoc-manual ruby \
   azure-cli powershell libgl1-mesa-dri shellcheck mercurial-common humanity-icon-theme google-cloud-cli
 
-echo "Listing 100 largest packages after"
-dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+# echo "Listing 100 largest packages after"
+# dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 
 # Directories
 sudo rm -fr /opt/ghc /opt/hostedtoolcache /usr/share/dotnet /usr/share/swift
@@ -28,4 +28,4 @@ sudo docker builder prune -a
 sudo apt autoremove -yq
 sudo apt clean
 
-df -h
+# df -h

--- a/packages/ghc-cross/hadrian-enable-iserv.diff
+++ b/packages/ghc-cross/hadrian-enable-iserv.diff
@@ -1,0 +1,18 @@
+# This Stage2 iserv will run under qemu emulated proot.
+
+--- ghc-9.12.1/hadrian/src/Settings/Default.hs	2025-02-24 22:46:43.668323779 +0530
++++ ghc-9.12.1.mod/hadrian/src/Settings/Default.hs	2025-03-02 14:45:19.932865008 +0530
+@@ -171,12 +173,12 @@
+         , transformers
+         , unlit
+         , xhtml
++        , iserv
+         , if winTarget then win32 else unix
+         ]
+       , when (not cross)
+         [ haddock
+         , hpcBin
+-        , iserv
+         , runGhc
+         , ghcToolchainBin
+         ]

--- a/packages/ghc-cross/hadrian-fix-program-rule.diff
+++ b/packages/ghc-cross/hadrian-fix-program-rule.diff
@@ -1,0 +1,17 @@
+--- ghc-9.12.1/hadrian/src/Rules/Program.hs	2025-02-24 22:46:43.666788988 +0530
++++ ghc-9.12.1.mod/hadrian/src/Rules/Program.hs	2025-02-26 23:01:57.610058317 +0530
+@@ -99,13 +99,7 @@
+   -- so we use pkgRegisteredLibraryFile instead.
+   registerPackages =<< contextDependencies ctx
+ 
+-  cross <- flag CrossCompiling
+-  -- For cross compiler, copy @stage0/bin/<pgm>@ to @stage1/bin/@.
+-  case (cross, stage) of
+-    (True, s) | s > stage0InTree -> do
+-        srcDir <- buildRoot <&> (-/- (stageString stage0InTree -/- "bin"))
+-        copyFile (srcDir -/- takeFileName bin) bin
+-    _ -> buildBinary rs bin ctx
++  buildBinary rs bin ctx
+ 
+ buildBinary :: [(Resource, Int)] -> FilePath -> Context -> Action ()
+ buildBinary rs bin context@Context {..} = do


### PR DESCRIPTION
- Added `ghc-iserv`. It will be used to cross-compile haskell-template.

Signed-off-by: Aditya Alok <alok@termux.dev>
